### PR TITLE
Python 3 support

### DIFF
--- a/httreplay/stubs/base.py
+++ b/httreplay/stubs/base.py
@@ -1,5 +1,5 @@
-from httplib import HTTPConnection, HTTPSConnection, HTTPMessage
-from cStringIO import StringIO
+from six.moves.http_client import HTTPConnection, HTTPSConnection, HTTPMessage
+from six import StringIO
 import logging
 import quopri
 import zlib

--- a/httreplay/utils.py
+++ b/httreplay/utils.py
@@ -1,5 +1,5 @@
 import urllib
-import urlparse
+from six.moves.urllib import parse as urlparse
 
 
 def sort_string(s):

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ Here's a very simple example of how to use it:
 There's a lot more you can do. Full documentation is available from the `httreplay github page <https://github.com/davepeck/httreplay>`_.
 """,
     packages=["httreplay", "httreplay.stubs"],
+    install_requires=["six == 1.5.2"],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I've added Python 3 support, while retaining Python 2 compatibility. This requires the installation of [six](https://pypi.python.org/pypi/six) (I've added it to `setup.py`)