### PR TITLE
Handle binary data in request body, and better handling of text in response body

### DIFF
--- a/httreplay/stubs/base.py
+++ b/httreplay/stubs/base.py
@@ -121,7 +121,7 @@ class ReplayConnectionHelper:
                 self.__request['body_base64'] = body_key.encode('base64')
 
         # endheaders() will eventually call send()
-        logstr = '%(method)s %(host)s:%(port)s/%(url)s' % self.__request
+        logstr = '%(method)s %(host)s:%(port)s%(url)s' % self.__request
         if self.__request in self.__recording:
             logger.debug("ReplayConnectionHelper found %s", logstr)
             self.__fake_send = True

--- a/httreplay/stubs/base.py
+++ b/httreplay/stubs/base.py
@@ -108,10 +108,17 @@ class ReplayConnectionHelper:
             # method already present
             url=url_key,
             headers=headers_key,
-            body=body_key,
             host=self.host,
             port=self.port,
         ))
+
+        # JSON encoder will try to decode bytes as UTF-8.
+        # Do this in advance so we have a chance to handle binary data.
+        if isinstance(body_key, str):
+            try:
+                self.__request['body'] = body_key.decode('utf8')
+            except UnicodeDecodeError:
+                self.__request['body_base64'] = body_key.encode('base64')
 
         # endheaders() will eventually call send()
         logstr = '%(method)s %(host)s:%(port)s/%(url)s' % self.__request

--- a/httreplay/stubs/base.py
+++ b/httreplay/stubs/base.py
@@ -269,7 +269,12 @@ class ReplayHTTPResponse(object):
                 replay_response['body_text'] = body
             except UnicodeDecodeError:
                 # Store body as quoted printable.
-                replay_response['body_quoted_printable'] = quopri.encodestring(body)
+                # Remove unneccessary =\n pairs which make searching hard.
+                # These exist for line-wrapping in email, which is entirely
+                # pointless here.
+                body_quoted_printable = quopri.encodestring(body)
+                body_quoted_printable = body_quoted_printable.replace('=\n', '')
+                replay_response['body_quoted_printable'] = body_quoted_printable
 
         else:
             replay_response['body'] = body.encode('base64')

--- a/httreplay/stubs/base.py
+++ b/httreplay/stubs/base.py
@@ -185,14 +185,13 @@ class ReplayHTTPSConnection(ReplayConnectionHelper, HTTPSConnection):
     _baseclass = HTTPSConnection
 
     def __init__(self, *args, **kwargs):
-        # I overrode the init and copied a lot of the code from the parent
-        # class because when this happens, HTTPConnection has been replaced
-        # by ReplayHTTPConnection,  but doing it here lets us use the original
-        # one.
-        HTTPConnection.__init__(self, *args, **kwargs)
-        ReplayConnectionHelper.__init__(self)
+        # httplib.HTTPConnection has been replaced by ReplayHTTPConnection,
+        # so doing it this way rather than calling through
+        # HTTPSConnection.__init__ allows us to use the original one.
         self.key_file = kwargs.pop('key_file', None)
         self.cert_file = kwargs.pop('cert_file', None)
+        HTTPConnection.__init__(self, *args, **kwargs)
+        ReplayConnectionHelper.__init__(self)
 
 
 class ReplayHTTPResponse(object):

--- a/httreplay/stubs/base.py
+++ b/httreplay/stubs/base.py
@@ -119,6 +119,9 @@ class ReplayConnectionHelper:
                 self.__request['body'] = body_key.decode('utf8')
             except UnicodeDecodeError:
                 self.__request['body_base64'] = body_key.encode('base64')
+        else:
+            # Probably unicode or None.
+            self.__request['body'] = body_key
 
         # endheaders() will eventually call send()
         logstr = '%(method)s %(host)s:%(port)s%(url)s' % self.__request


### PR DESCRIPTION
Binary data in request body would cause an exception as JSON encoder attempts to decode as UTF-8.  Catch this in advance and convert to base64.

Text data in response body has been stored as quoted printable, but this is annoyingly overcooked most of the time, and is hard to manually search and replace data in traces.  Try to store response body as UTF-8 encoded text first, falling back to quoted printable only when necessary.

Neither of these change should break request keys or responses for existing traces.